### PR TITLE
make some adjustments to the table tutorial

### DIFF
--- a/tutorials/FITS-tables/FITS-tables.ipynb
+++ b/tutorials/FITS-tables/FITS-tables.ipynb
@@ -218,7 +218,6 @@
    "outputs": [],
    "source": [
     "ii = np.in1d(evt_data['ccd_id'], [0, 1, 2, 3])\n",
-    "ii = np.in1d(evt_data['ccd_id'], [5, 6])\n",
     "np.sum(ii)"
    ]
   },

--- a/tutorials/FITS-tables/FITS-tables.ipynb
+++ b/tutorials/FITS-tables/FITS-tables.ipynb
@@ -4,16 +4,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
     "import numpy as np\n",
     "\n",
-    "# Set up matplotlib and use a nicer set of plot parameters\n",
-    "%config InlineBackend.rc = {}\n",
-    "import matplotlib\n",
-    "matplotlib.rc_file(\"../../templates/matplotlibrc\")\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
    ]
@@ -139,7 +135,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now I'll load the data into a separate variable."
+    "Now I'll we'll take this data and convert it into an [astropy table](http://docs.astropy.org/en/stable/table/). While it is possible to access FITS tables directly from the ``.data`` attribute, using [Table](http://docs.astropy.org/en/stable/api/astropy.table.Table.html#astropy.table.Table) tends to make a variety of common tasks more convenient."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from astropy.table import Table\n",
+    "\n",
+    "evt_data = Table(hdu_list[1].data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, a preview of the table is easily viewed by simply running a cell with the table as the last line:"
    ]
   },
   {
@@ -150,21 +166,14 @@
    },
    "outputs": [],
    "source": [
-    "evt_data = hdu_list[1].data"
+    "evt_data"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can extract data from the table by referencing the column name."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "For example, I'll make a histogram for the energy of each photon, giving us a sense for the spectrum (folded with the detector's efficiency)."
+    "We can extract data from the table by referencing the column name.. For example, I'll make a histogram for the energy of each photon, giving us a sense for the spectrum (folded with the detector's efficiency)."
    ]
   },
   {
@@ -194,22 +203,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "x = evt_data['x']\n",
-    "y = evt_data['y']"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This particular observation spans five CCD chips.  Here I will pick events that only fell on the main (ACIS-I) chips, which have number ids 0, 1, 2, and 3."
+    "This particular observation spans five CCD chips.  First we determine the events that only fell on the main (ACIS-I) chips, which have number ids 0, 1, 2, and 3."
    ]
   },
   {
@@ -220,7 +217,9 @@
    },
    "outputs": [],
    "source": [
-    "ii = np.any([evt_data['ccd_id'] == i for i in [0,1,2,3]], axis=0)"
+    "ii = np.in1d(evt_data['ccd_id'], [0, 1, 2, 3])\n",
+    "ii = np.in1d(evt_data['ccd_id'], [5, 6])\n",
+    "np.sum(ii)"
    ]
   },
   {
@@ -304,6 +303,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When you're done using a FITS file, it's often a good idea to close it.  That way you can be sure it won't continue using up excess memory or file handles on your computer.  (This happens automatically when you close Python, but you never know how long that might be...)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -380,21 +386,21 @@
    "published": true
   },
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Made some changes (meant for astropy/astropy-tutorials#108), mostly explanation, but two notable changes:

* removed the custom matplotlibrc stuff from the top cell.  That should cause fewer problems when users just download the file
* changed to using `astropy.table.Table` to turn the fits table into an astropy Table.  I'd say this is usually the recommended practice now, as it works and just makes a number of things easier.